### PR TITLE
TrackingActivity ViewModel 분리하기

### DIFF
--- a/app/src/main/java/com/boostcamp/travery/Constants.kt
+++ b/app/src/main/java/com/boostcamp/travery/Constants.kt
@@ -1,6 +1,9 @@
 package com.boostcamp.travery
 
 object Constants {
+    const val UPDATE_INTERVAL_MS: Long = 2500  // 1초
+    const val FASTEST_UPDATE_INTERVAL_MS: Long = 1500 //
+
     const val EXTRA_COURSE_LOCATION_LIST = "ROUTE_LOCATION_LIST"
     const val EXTRA_COURSE = "COURSE"
     const val EXTRA_LATITUDE = "LATITUDE"

--- a/app/src/main/java/com/boostcamp/travery/data/repository/MapTrackingRepository.kt
+++ b/app/src/main/java/com/boostcamp/travery/data/repository/MapTrackingRepository.kt
@@ -1,21 +1,21 @@
-package com.boostcamp.travery.mapservice
+package com.boostcamp.travery.data.repository
 
-import android.util.Log
 import com.boostcamp.travery.data.model.Suggestion
 import com.boostcamp.travery.data.model.TimeCode
+import com.boostcamp.travery.eventbus.EventBus
 import com.google.android.gms.maps.model.LatLng
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 
 class MapTrackingRepository {
     private val timeCodeList = ArrayList<TimeCode>()
-    private val timeCode : PublishSubject<TimeCode> = PublishSubject.create()
+    private val timeCode: PublishSubject<TimeCode> = PublishSubject.create()
 
     private val suggestList = ArrayList<Suggestion>()
-    private val suggest : PublishSubject<Int> = PublishSubject.create()
+    private val suggest: PublishSubject<Int> = PublishSubject.create()
     private var suggestListSize = 0
 
-    private val second : PublishSubject<Int> = PublishSubject.create()
+    private val second: PublishSubject<Int> = PublishSubject.create()
 
     private val userActionLocateList = ArrayList<LatLng>()
 
@@ -26,27 +26,29 @@ class MapTrackingRepository {
         @Volatile
         private var INSTANCE: MapTrackingRepository? = null
 
-        fun getInstance() = INSTANCE ?: synchronized(this) {
-            INSTANCE ?: MapTrackingRepository().also { INSTANCE = it }
-        }
+        fun getInstance() = INSTANCE
+                ?: synchronized(this) {
+                    INSTANCE
+                            ?: MapTrackingRepository().also { INSTANCE = it }
+                }
     }
 
-    fun addTotalDistance(distance: Float){
+    fun addTotalDistance(distance: Float) {
         totalDistance += distance.toLong()
     }
 
-    fun getTotalDistance(): Long{
+    fun getTotalDistance(): Long {
         return totalDistance
     }
 
     fun addTimeCode(timeCode: TimeCode) {
-        if(startTime != 0L)
+        if (startTime != 0L)
             timeCodeList.add(timeCode)
         this.timeCode.onNext(timeCode)
         //Log.d("lolocation",timeCode.toString())
     }
 
-    fun setSecond(second: Int){
+    fun setSecond(second: Int) {
         this.second.onNext(second)
     }
 
@@ -54,7 +56,7 @@ class MapTrackingRepository {
         return second
     }
 
-   fun getTimeCode(): Observable<TimeCode> {
+    fun getTimeCode(): Observable<TimeCode> {
         return timeCode
     }
 
@@ -68,13 +70,14 @@ class MapTrackingRepository {
 
     fun setStartTime(startTime: Long) {
         this.startTime = startTime
+        EventBus.sendEvent(ServiceStartEvent(startTime))
     }
 
     fun getSuggest(): Observable<Int> {
         return suggest
     }
 
-    fun getSuggestListSize(): Int{
+    fun getSuggestListSize(): Int {
         return suggestListSize
     }
 
@@ -83,7 +86,7 @@ class MapTrackingRepository {
     }
 
     fun addSuggest(suggest: Suggestion) {
-        if(startTime != 0L)
+        if (startTime != 0L)
             suggestList.add(suggest)
         suggestListSize++
         this.suggest.onNext(suggestListSize)
@@ -104,13 +107,16 @@ class MapTrackingRepository {
         totalDistance = 0L
         suggestListSize = 0
         this.suggest.onNext(suggestListSize)
+        EventBus.sendEvent(ServiceStartEvent(startTime))
     }
 
-    fun addUserActionLocate(locate: LatLng){
+    fun addUserActionLocate(locate: LatLng) {
         userActionLocateList.add(locate)
     }
 
-    fun getUserActionLocateList(): ArrayList<LatLng>{
+    fun getUserActionLocateList(): ArrayList<LatLng> {
         return userActionLocateList
     }
 }
+
+data class ServiceStartEvent(val startTime: Long)

--- a/app/src/main/java/com/boostcamp/travery/data/repository/MapTrackingRepository.kt
+++ b/app/src/main/java/com/boostcamp/travery/data/repository/MapTrackingRepository.kt
@@ -45,7 +45,6 @@ class MapTrackingRepository {
         if (startTime != 0L)
             timeCodeList.add(timeCode)
         this.timeCode.onNext(timeCode)
-        //Log.d("lolocation",timeCode.toString())
     }
 
     fun setSecond(second: Int) {

--- a/app/src/main/java/com/boostcamp/travery/mapservice/MapTrackingRepository.kt
+++ b/app/src/main/java/com/boostcamp/travery/mapservice/MapTrackingRepository.kt
@@ -12,7 +12,8 @@ class MapTrackingRepository {
     private val timeCode : PublishSubject<TimeCode> = PublishSubject.create()
 
     private val suggestList = ArrayList<Suggestion>()
-    private val suggest : PublishSubject<Suggestion> = PublishSubject.create()
+    private val suggest : PublishSubject<Int> = PublishSubject.create()
+    private var suggestListSize = 0
 
     private val second : PublishSubject<Int> = PublishSubject.create()
 
@@ -69,8 +70,12 @@ class MapTrackingRepository {
         this.startTime = startTime
     }
 
-    fun getSuggest(): Observable<Suggestion> {
+    fun getSuggest(): Observable<Int> {
         return suggest
+    }
+
+    fun getSuggestListSize(): Int{
+        return suggestListSize
     }
 
     fun getSuggestList(): ArrayList<Suggestion> {
@@ -80,25 +85,32 @@ class MapTrackingRepository {
     fun addSuggest(suggest: Suggestion) {
         if(startTime != 0L)
             suggestList.add(suggest)
-        this.suggest.onNext(suggest)
+        suggestListSize++
+        this.suggest.onNext(suggestListSize)
     }
 
     fun removeSuggestItem(position: Int) {
         suggestList.removeAt(position)
+        suggestListSize--
+        this.suggest.onNext(suggestListSize)
     }
 
     fun clearData() {
         timeCodeList.clear()
         suggestList.clear()
+        userActionLocateList.clear()
+
         startTime = 0L
         totalDistance = 0L
+        suggestListSize = 0
+        this.suggest.onNext(suggestListSize)
     }
 
     fun addUserActionLocate(locate: LatLng){
         userActionLocateList.add(locate)
     }
 
-    fun getUsetActionLocateList(): ArrayList<LatLng>{
+    fun getUserActionLocateList(): ArrayList<LatLng>{
         return userActionLocateList
     }
 }

--- a/app/src/main/java/com/boostcamp/travery/mapservice/MapTrackingRepository.kt
+++ b/app/src/main/java/com/boostcamp/travery/mapservice/MapTrackingRepository.kt
@@ -1,0 +1,104 @@
+package com.boostcamp.travery.mapservice
+
+import android.util.Log
+import com.boostcamp.travery.data.model.Suggestion
+import com.boostcamp.travery.data.model.TimeCode
+import com.google.android.gms.maps.model.LatLng
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
+
+class MapTrackingRepository {
+    private val timeCodeList = ArrayList<TimeCode>()
+    private val timeCode : PublishSubject<TimeCode> = PublishSubject.create()
+
+    private val suggestList = ArrayList<Suggestion>()
+    private val suggest : PublishSubject<Suggestion> = PublishSubject.create()
+
+    private val second : PublishSubject<Int> = PublishSubject.create()
+
+    private val userActionLocateList = ArrayList<LatLng>()
+
+    private var startTime = 0L
+    private var totalDistance = 0L
+
+    companion object {
+        @Volatile
+        private var INSTANCE: MapTrackingRepository? = null
+
+        fun getInstance() = INSTANCE ?: synchronized(this) {
+            INSTANCE ?: MapTrackingRepository().also { INSTANCE = it }
+        }
+    }
+
+    fun addTotalDistance(distance: Float){
+        totalDistance += distance.toLong()
+    }
+
+    fun getTotalDistance(): Long{
+        return totalDistance
+    }
+
+    fun addTimeCode(timeCode: TimeCode) {
+        if(startTime != 0L)
+            timeCodeList.add(timeCode)
+        this.timeCode.onNext(timeCode)
+        //Log.d("lolocation",timeCode.toString())
+    }
+
+    fun setSecond(second: Int){
+        this.second.onNext(second)
+    }
+
+    fun getSecond(): Observable<Int> {
+        return second
+    }
+
+   fun getTimeCode(): Observable<TimeCode> {
+        return timeCode
+    }
+
+    fun getTimeCodeList(): ArrayList<TimeCode> {
+        return timeCodeList
+    }
+
+    fun getStartTime(): Long {
+        return startTime
+    }
+
+    fun setStartTime(startTime: Long) {
+        this.startTime = startTime
+    }
+
+    fun getSuggest(): Observable<Suggestion> {
+        return suggest
+    }
+
+    fun getSuggestList(): ArrayList<Suggestion> {
+        return suggestList
+    }
+
+    fun addSuggest(suggest: Suggestion) {
+        if(startTime != 0L)
+            suggestList.add(suggest)
+        this.suggest.onNext(suggest)
+    }
+
+    fun removeSuggestItem(position: Int) {
+        suggestList.removeAt(position)
+    }
+
+    fun clearData() {
+        timeCodeList.clear()
+        suggestList.clear()
+        startTime = 0L
+        totalDistance = 0L
+    }
+
+    fun addUserActionLocate(locate: LatLng){
+        userActionLocateList.add(locate)
+    }
+
+    fun getUsetActionLocateList(): ArrayList<LatLng>{
+        return userActionLocateList
+    }
+}

--- a/app/src/main/java/com/boostcamp/travery/mapservice/MapTrackingService.kt
+++ b/app/src/main/java/com/boostcamp/travery/mapservice/MapTrackingService.kt
@@ -18,7 +18,6 @@ import android.os.*
 import androidx.core.app.TaskStackBuilder
 import com.boostcamp.travery.data.model.Suggestion
 import com.boostcamp.travery.data.model.TimeCode
-import kotlin.collections.ArrayList
 
 
 @SuppressLint("Registered")
@@ -40,12 +39,10 @@ class MapTrackingService : Service() {
     private val UPDATE_INTERVAL_MS: Long = 2500  // 1초
     private val FASTEST_UPDATE_INTERVAL_MS: Long = 1500 //
 
-    private val userActionPositionList: ArrayList<LatLng> = ArrayList()
     private var lostLocationCnt = 0
     //private val timeCodeList: ArrayList<TimeCode> = ArrayList()
     var isRunning = false
     private var canSuggest = true
-    private val suggestList: ArrayList<Suggestion> = ArrayList()
     private var startTime: Long? = null
     private var second: Int = 0
 
@@ -173,6 +170,11 @@ class MapTrackingService : Service() {
 
         secondTimer.schedule(SecondTimer(), 1000, 1000)
 
+        getLastKnownLocation()?.let {
+            mapTrackingRepository.addTimeCode(TimeCode(LatLng(it.latitude, it.longitude), it.time))
+        }
+
+
         startTime = System.currentTimeMillis()
         mapTrackingRepository.setStartTime(startTime ?: 0L)
         mCallback?.saveInitCourse(startTime ?: System.currentTimeMillis())
@@ -189,9 +191,6 @@ class MapTrackingService : Service() {
             if (bestLocation == null || mLocation.accuracy < bestLocation.accuracy) {
                 bestLocation = mLocation
             }
-        }
-        if (isRunning && bestLocation != null) {
-            //timeCodeList.add(TimeCode(LatLng(bestLocation.latitude, bestLocation.longitude), bestLocation.time))
         }
         return bestLocation
     }

--- a/app/src/main/java/com/boostcamp/travery/mapservice/MapTrackingService.kt
+++ b/app/src/main/java/com/boostcamp/travery/mapservice/MapTrackingService.kt
@@ -39,7 +39,6 @@ class MapTrackingService : Service() {
 
 
     private var lostLocationCnt = 0
-    //private val timeCodeList: ArrayList<TimeCode> = ArrayList()
     var isRunning = false
     private var canSuggest = true
     private var second: Int = 0
@@ -89,7 +88,6 @@ class MapTrackingService : Service() {
                         val locate = LatLng(location.latitude, location.longitude)
                         mapTrackingRepository.addTotalDistance(location.distanceTo(exLocation))
                         mapTrackingRepository.addTimeCode(TimeCode(locate, location.time))
-                        //mCallback?.sendLocation(locate, location.accuracy)
 
                         exLocation = location
 
@@ -99,14 +97,12 @@ class MapTrackingService : Service() {
                         } else {//1.5초에서 2.5초에 한번 씩 데이터가 들어옴
                             //200번 쌓이면 5분
                             if (lostLocationCnt > 1 && canSuggest) {
-                                Log.d("lolott", "제안 추가")
                                 mapTrackingRepository.addSuggest(Suggestion(
                                         LatLng(
                                                 standardLocation.latitude,
                                                 standardLocation.longitude
                                         ), standardLocation.time, location.time
                                 ))
-                                //mCallback?.sendSuggestList(suggestList)
                             }
                             standardLocation = location
                             canSuggest = true

--- a/app/src/main/java/com/boostcamp/travery/mapservice/SuggestListAdapter.kt
+++ b/app/src/main/java/com/boostcamp/travery/mapservice/SuggestListAdapter.kt
@@ -15,11 +15,8 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 class SuggestListAdapter(
-        context: Context,
         private val suggestList: ArrayList<Suggestion>
 ) : BaseAdapter() {
-
-    private val layoutInflater: LayoutInflater = LayoutInflater.from(context)
 
     override fun getCount(): Int {
         return suggestList.size
@@ -39,7 +36,7 @@ class SuggestListAdapter(
         var view: View? = convertView
 
         if (view == null) {
-            view = layoutInflater.inflate(R.layout.item_suggest_list, parent, false)
+            view = LayoutInflater.from(parent.context).inflate(R.layout.item_suggest_list, parent, false)
 
             viewHolder = ViewHolder(
                     view.findViewById(R.id.tv_date),

--- a/app/src/main/java/com/boostcamp/travery/mapservice/TrackingActivity.kt
+++ b/app/src/main/java/com/boostcamp/travery/mapservice/TrackingActivity.kt
@@ -95,8 +95,6 @@ class TrackingActivity : BaseActivity<ActivityTrackingBinding>(), OnMapReadyCall
     fun startService(v: View) {
         val serviceIntent = Intent(this, MapTrackingService::class.java)
         ContextCompat.startForegroundService(this, serviceIntent)
-        //startRecordView()
-        //isService = true
         polylineOptions = PolylineOptions()
                 .color(Color.BLUE)
                 .geodesic(true)
@@ -267,7 +265,6 @@ class TrackingActivity : BaseActivity<ActivityTrackingBinding>(), OnMapReadyCall
 
         override fun onServiceDisconnected(name: ComponentName) {
             // 서비스와 연결이 끊겼을 때 호출되는 메서드
-            Log.d("loloser", "disconnect")
         }
     }
 

--- a/app/src/main/java/com/boostcamp/travery/mapservice/TrackingActivity.kt
+++ b/app/src/main/java/com/boostcamp/travery/mapservice/TrackingActivity.kt
@@ -46,7 +46,6 @@ class TrackingActivity : BaseActivity<ActivityTrackingBinding>(), OnMapReadyCall
         get() = R.layout.activity_tracking
 
     lateinit var mapService: MapTrackingService
-    //var isService = false
     private lateinit var mMap: GoogleMap
     private lateinit var myLocationMarker: Marker
     private var suggestionMarker: Marker? = null
@@ -97,7 +96,6 @@ class TrackingActivity : BaseActivity<ActivityTrackingBinding>(), OnMapReadyCall
         val serviceIntent = Intent(this, MapTrackingService::class.java)
         ContextCompat.startForegroundService(this, serviceIntent)
         //startRecordView()
-        viewModel.setIsServiceState(true)
         //isService = true
         polylineOptions = PolylineOptions()
                 .color(Color.BLUE)
@@ -237,36 +235,16 @@ class TrackingActivity : BaseActivity<ActivityTrackingBinding>(), OnMapReadyCall
 
     private var mapTrackingServiceConnection: ServiceConnection = object : ServiceConnection {
 
-        private val mCallback = object : MapTrackingService.ICallback {
-
-            override fun saveInitCourse(startTime: Long) {
-                AppDataManager(application, AppDbHelper.getInstance(application)).saveCourse(
-                        Course(startTime = startTime)
-                ).subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread()).subscribe()
-            }
-
-            /* 서비스에서 데이터를 받아 메소드 호출 또는 핸들러로 전달 */
-        }
-
         override fun onServiceConnected(
                 name: ComponentName,
-                service: IBinder
-        ) {
+                service: IBinder) {
             // 서비스와 연결되었을 때 호출되는 메서드
             // 서비스 객체를 전역변수로 저장
             val mb = service as MapTrackingService.LocalBinder
             mapService = mb.service // 서비스가 제공하는 메소드 호출하여
-            mapService.registerCallback(mCallback)
-            // 서비스쪽 객체를 전달받을수 있슴
-            viewModel.setIsServiceState(mapService.isRunning)
 
-            val location = mapService.getLastLocation()
-            //서울 위치
-
-            if (location != null) {
-                val lat = location.latitude
-                val lng = location.longitude
-                val myLocation = LatLng(lat, lng)
+            mapService.getLastLocation()?.let {
+                val myLocation = LatLng(it.latitude, it.longitude)
                 myLocationMarker.position = myLocation
                 mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(myLocation, 15f))
             }
@@ -289,7 +267,7 @@ class TrackingActivity : BaseActivity<ActivityTrackingBinding>(), OnMapReadyCall
 
         override fun onServiceDisconnected(name: ComponentName) {
             // 서비스와 연결이 끊겼을 때 호출되는 메서드
-            viewModel.setIsServiceState(false)
+            Log.d("loloser", "disconnect")
         }
     }
 

--- a/app/src/main/java/com/boostcamp/travery/mapservice/TrackingActivity.kt
+++ b/app/src/main/java/com/boostcamp/travery/mapservice/TrackingActivity.kt
@@ -150,7 +150,7 @@ class TrackingActivity : BaseActivity<ActivityTrackingBinding>(), OnMapReadyCall
 
         val serviceIntent = Intent(this, MapTrackingService::class.java)
         stopService(serviceIntent)
-
+        removeSuggestionMarker()
         mMap.clear()
 
         doBindService()

--- a/app/src/main/java/com/boostcamp/travery/mapservice/TrackingViewModel.kt
+++ b/app/src/main/java/com/boostcamp/travery/mapservice/TrackingViewModel.kt
@@ -3,8 +3,11 @@ package com.boostcamp.travery.mapservice
 import android.app.Application
 import android.location.Location
 import android.util.Log
+import android.widget.BaseAdapter
+import androidx.databinding.ObservableBoolean
 import com.boostcamp.travery.base.BaseViewModel
 import androidx.databinding.ObservableField
+import androidx.databinding.ObservableInt
 import androidx.lifecycle.MutableLiveData
 import com.boostcamp.travery.data.model.Suggestion
 import com.boostcamp.travery.data.model.TimeCode
@@ -17,24 +20,30 @@ class TrackingViewModel(application: Application) : BaseViewModel(application) {
 
     private val mapTrackingRepository = MapTrackingRepository.getInstance()
     var secondString = ObservableField<String>("")
-    val isService = ObservableField<Boolean>(false)
+    val isService = ObservableBoolean(false)
     val curLocation = MutableLiveData<LatLng>()
-    val suggestionList = MutableLiveData<ArrayList<Suggestion>>()
+    var suggestCountString = ObservableField<String>("0")
+    //val suggestionList = MutableLiveData<ArrayList<Suggestion>>()
     val totalDistance by lazy { mapTrackingRepository.getTotalDistance() }
     val startTime by lazy { mapTrackingRepository.getStartTime() }
-    val userActionLocateList by lazy { mapTrackingRepository.getUsetActionLocateList() }
+    val userActionLocateList by lazy { mapTrackingRepository.getUserActionLocateList() }
+    private var suggestAdapter: BaseAdapter? = null
 
     init {
+
         addDisposable(
                 mapTrackingRepository.getTimeCode().subscribe {
                     curLocation.value = it.coordinate
                 }
         )
 
+        suggestCountString.set(mapTrackingRepository.getSuggestListSize().toString())
+
         addDisposable(
                 mapTrackingRepository.getSuggest().subscribe {
-                    Log.d("lolocation", mapTrackingRepository.getSuggestList().toString())
-                    suggestionList.value = mapTrackingRepository.getSuggestList()
+                    //suggestionList.value = mapTrackingRepository.getSuggestList()
+                    suggestCountString.set(it.toString())
+                    suggestAdapter?.notifyDataSetChanged()
                 }
         )
 
@@ -64,16 +73,16 @@ class TrackingViewModel(application: Application) : BaseViewModel(application) {
         return mapTrackingRepository.getTimeCodeList()
     }
 
-    fun getSuggestList(): ArrayList<Suggestion> {
+    /*fun getSuggestList(): ArrayList<Suggestion> {
         return mapTrackingRepository.getSuggestList()
-    }
+    }*/
 
     fun removeSuggestItem(position: Int) {
         mapTrackingRepository.removeSuggestItem(position)
     }
 
     fun getIsServiceState(): Boolean {
-        return isService.get() ?: false
+        return isService.get()
     }
 
     fun setIsServiceState(boolean: Boolean) {
@@ -82,5 +91,10 @@ class TrackingViewModel(application: Application) : BaseViewModel(application) {
 
     fun addUserActionLocate(locate: LatLng){
         mapTrackingRepository.addUserActionLocate(locate)
+    }
+
+    fun getSuggestAdapter(): BaseAdapter{
+        suggestAdapter = SuggestListAdapter(mapTrackingRepository.getSuggestList())
+        return suggestAdapter!!
     }
 }

--- a/app/src/main/java/com/boostcamp/travery/mapservice/TrackingViewModel.kt
+++ b/app/src/main/java/com/boostcamp/travery/mapservice/TrackingViewModel.kt
@@ -1,13 +1,76 @@
 package com.boostcamp.travery.mapservice
 
 import android.app.Application
+import android.location.Location
+import android.util.Log
 import com.boostcamp.travery.base.BaseViewModel
 import androidx.databinding.ObservableField
+import androidx.lifecycle.MutableLiveData
+import com.boostcamp.travery.data.model.Suggestion
+import com.boostcamp.travery.data.model.TimeCode
+import com.google.android.gms.maps.model.LatLng
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
 
 
 class TrackingViewModel(application: Application) : BaseViewModel(application) {
 
+    private val mapTrackingRepository = MapTrackingRepository.getInstance()
+    var secondString = ObservableField<String>("")
     val isService = ObservableField<Boolean>(false)
+    val curLocation = MutableLiveData<LatLng>()
+    val suggestionList = MutableLiveData<ArrayList<Suggestion>>()
+    val totalDistance by lazy { mapTrackingRepository.getTotalDistance() }
+    val startTime by lazy { mapTrackingRepository.getStartTime() }
+    val userActionLocateList by lazy { mapTrackingRepository.getUsetActionLocateList() }
+
+    init {
+        addDisposable(
+                mapTrackingRepository.getTimeCode().subscribe {
+                    curLocation.value = it.coordinate
+                }
+        )
+
+        addDisposable(
+                mapTrackingRepository.getSuggest().subscribe {
+                    Log.d("lolocation", mapTrackingRepository.getSuggestList().toString())
+                    suggestionList.value = mapTrackingRepository.getSuggestList()
+                }
+        )
+
+        addDisposable(
+                mapTrackingRepository.getSecond()
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe {
+                            secondString.set(setIntToTime(it))
+                        })
+
+        if (mapTrackingRepository.getStartTime() != 0L)
+            isService.set(true)
+    }
+
+    private fun setIntToTime(timeInt: Int): String {
+
+        var min = timeInt / 60
+        val hour = min / 60
+        val sec = timeInt % 60
+        min %= 60
+
+        return "${String.format("%02d", hour)}:${String.format("%02d", min)}:${String.format("%02d", sec)}"
+    }
+
+    fun getTimeCodeList(): ArrayList<TimeCode> {
+        return mapTrackingRepository.getTimeCodeList()
+    }
+
+    fun getSuggestList(): ArrayList<Suggestion> {
+        return mapTrackingRepository.getSuggestList()
+    }
+
+    fun removeSuggestItem(position: Int) {
+        mapTrackingRepository.removeSuggestItem(position)
+    }
 
     fun getIsServiceState(): Boolean {
         return isService.get() ?: false
@@ -15,5 +78,9 @@ class TrackingViewModel(application: Application) : BaseViewModel(application) {
 
     fun setIsServiceState(boolean: Boolean) {
         isService.set(boolean)
+    }
+
+    fun addUserActionLocate(locate: LatLng){
+        mapTrackingRepository.addUserActionLocate(locate)
     }
 }

--- a/app/src/main/java/com/boostcamp/travery/mapservice/savecourse/CourseSaveViewModel.kt
+++ b/app/src/main/java/com/boostcamp/travery/mapservice/savecourse/CourseSaveViewModel.kt
@@ -40,7 +40,7 @@ class CourseSaveViewModel(application: Application) : BaseViewModel(application)
         val colms = JSONObject()
 
         var marker = ""
-        if(timeCodeList.size >= 2) {
+        if (timeCodeList.size >= 2) {
             marker = "&markers=color:red%7C${timeCodeList[0].coordinate.latitude},${timeCodeList[0].coordinate.longitude}" +
                     "&markers=color:blue%7C${timeCodeList.last().coordinate.latitude},${timeCodeList.last().coordinate.longitude}"
         }
@@ -79,8 +79,7 @@ class CourseSaveViewModel(application: Application) : BaseViewModel(application)
             Completable.fromAction {
                 FileUtils.saveJsonFile(
                         getApplication(), mCourse.startTime.toString(), makeCoordinateJson(
-                        it.getParcelableArrayList<TimeCode>(Constants.EXTRA_COURSE_LOCATION_LIST)!!
-                )
+                        it.getParcelableArrayList<TimeCode>(Constants.EXTRA_COURSE_LOCATION_LIST)!!)
                 )
             }.doOnComplete {
                 val course = Course(

--- a/app/src/main/res/layout/activity_tracking.xml
+++ b/app/src/main/res/layout/activity_tracking.xml
@@ -36,21 +36,22 @@
             android:layout_margin="10dp"
             android:onClick="openSuggestDialog"
             android:src="@drawable/ic_add_alert_black_24dp"
+            app:tint="@color/colorAccent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/include"
-            app:visibility="@{viewmodel.isService}"/>
+            app:visibility='@{!viewmodel.suggestCountString.equals("0")}'/>
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_seggest_num"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="0"
+            android:text="@{viewmodel.suggestCountString}"
             android:textColor="@color/colorAccent"
             android:textSize="16sp"
             android:textStyle="bold"
             app:layout_constraintRight_toRightOf="@+id/btn_suggest"
             app:layout_constraintTop_toTopOf="@+id/btn_suggest"
-            app:visibility="@{viewmodel.isService}"/>
+            app:visibility='@{!viewmodel.suggestCountString.equals("0")}'/>
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/img_midMarker"

--- a/app/src/main/res/layout/activity_tracking.xml
+++ b/app/src/main/res/layout/activity_tracking.xml
@@ -132,6 +132,7 @@
             android:layout_height="wrap_content"
             android:textSize="16sp"
             android:textStyle="bold"
+            android:text="@{viewmodel.secondString}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,8 +30,8 @@
     <string name="suggestion_dialog_description">확인하지 않은 활동 추가 제안이 남아 있습니다. 제안을 무시하고 저장하시겠습니까?
     </string>
 
-    <string name="service_title">Example Service</string>
-    <string name="service_message">활동 기록 중 입니다.</string>
+    <string name="service_title">Travery Service</string>
+    <string name="service_message">활동을 기록하고 있습니다.</string>
 
     <string name="string_et_course_add_hint">제목을 입력하세요(20자 이내)</string>
     <string name="string_et_course_add_content_hint">현재 코스를 한줄로 표현해주세요</string>


### PR DESCRIPTION
## 개요
mapservice와 activity가 bind되어 콜백으로 서로 연결되어 있는 것을 끊기 위하여
repository 싱글톤을 사용하였습니다.

서비스에서 repo에 데이터를 주입하고 viewmodel에서 데이터를 subscribe 하도록 구현하였습니다.


## 이슈
resolved #70 

