### PR TITLE
(#128) 활동 피드 화면 구성 완료

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.boostcamp.travery">
+    package="com.boostcamp.travery">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.CAMERA"/>
-    <uses-permission android:name=" android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name=" android.permission.FOREGROUND_SERVICE" />
 
-    <uses-feature android:name="android.hardware.location.gps"/>
+    <uses-feature android:name="android.hardware.location.gps" />
 
     <application
         android:name=".MyApplication"
@@ -21,44 +21,36 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme.NoActionBar">
-        <activity android:name=".useraction.list.UserActionListActivity">
-        </activity>
-        <activity android:name=".useraction.detail.UserActionDetailActivity">
-        </activity>
-        <activity android:name=".useraction.save.UserActionSaveActivity">
-        </activity>
-        <activity android:name=".mapservice.savecourse.CourseSaveActivity">
-        </activity>
+        <activity android:name=".useraction.list.UserActionFeedActivity"></activity>
+        <activity android:name=".useraction.list.UserActionListActivity"></activity>
+        <activity android:name=".useraction.detail.UserActionDetailActivity"></activity>
+        <activity android:name=".useraction.save.UserActionSaveActivity"></activity>
+        <activity android:name=".mapservice.savecourse.CourseSaveActivity"></activity>
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="@string/google_maps_key"/>
+            android:value="@string/google_maps_key" />
 
         <activity
             android:name=".mapservice.TrackingActivity"
-            android:parentActivityName=".main.MainActivity"
             android:launchMode="singleTask"
-            android:screenOrientation="portrait">
-        </activity>
-        <activity android:name=".search.SearchResultActivity">
-        </activity>
+            android:parentActivityName=".main.MainActivity"
+            android:screenOrientation="portrait"></activity>
+        <activity android:name=".search.SearchResultActivity"></activity>
+        <activity android:name=".main.MainActivity"></activity>
+        <activity android:name=".coursedetail.CourseDetailActivity" />
         <activity
-            android:name=".main.MainActivity"
-        >
-
-        </activity>
-        <activity android:name=".coursedetail.CourseDetailActivity"/>
-        <activity android:name=".SplashActivity"
-                  android:theme="@style/AppTheme.NoActionBar.Fullscreen">
+            android:name=".SplashActivity"
+            android:theme="@style/AppTheme.NoActionBar.Fullscreen">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <action android:name="android.intent.action.VIEW"/>
+                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.VIEW" />
 
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
-        <service android:name=".mapservice.MapTrackingService"/>
+        <service android:name=".mapservice.MapTrackingService" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/boostcamp/travery/main/MainActivity.kt
+++ b/app/src/main/java/com/boostcamp/travery/main/MainActivity.kt
@@ -21,6 +21,7 @@ import com.boostcamp.travery.data.model.Course
 import com.boostcamp.travery.databinding.ActivityMainBinding
 import com.boostcamp.travery.mapservice.TrackingActivity
 import com.boostcamp.travery.search.SearchResultActivity
+import com.boostcamp.travery.useraction.list.UserActionFeedActivity
 import com.boostcamp.travery.useraction.list.UserActionListActivity
 import com.boostcamp.travery.useraction.save.UserActionSaveActivity
 import com.google.android.material.navigation.NavigationView
@@ -133,7 +134,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(), NavigationView.OnNavig
                 startActivity(Intent(this, UserActionListActivity::class.java))
             }
             R.id.nav_gallery -> {
-                startActivity(Intent(this, SearchResultActivity::class.java))
+//                startActivity(Intent(this, SearchResultActivity::class.java))
+                startActivity(Intent(this, UserActionFeedActivity::class.java))
             }
             R.id.nav_slideshow -> {
                 startActivity(Intent(this, UserActionSaveActivity::class.java))

--- a/app/src/main/java/com/boostcamp/travery/useraction/list/UserActionFeedActivity.kt
+++ b/app/src/main/java/com/boostcamp/travery/useraction/list/UserActionFeedActivity.kt
@@ -1,0 +1,24 @@
+package com.boostcamp.travery.useraction.list
+
+import android.os.Bundle
+import androidx.appcompat.widget.Toolbar
+import androidx.lifecycle.ViewModelProviders
+import com.boostcamp.travery.R
+import com.boostcamp.travery.base.BaseActivity
+import com.boostcamp.travery.databinding.ActivityUserActionFeedBinding
+import kotlinx.android.synthetic.main.activity_user_action_feed.*
+
+class UserActionFeedActivity : BaseActivity<ActivityUserActionFeedBinding>() {
+    override val layoutResourceId: Int
+        get() = R.layout.activity_user_action_feed
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(viewDataBinding.root)
+
+        setSupportActionBar(toolBar as Toolbar)
+        supportActionBar?.title = ""
+
+        viewDataBinding.viewmodel = ViewModelProviders.of(this).get(UserActionListViewModel::class.java)
+    }
+}

--- a/app/src/main/java/com/boostcamp/travery/useraction/list/UserActionFeedActivity.kt
+++ b/app/src/main/java/com/boostcamp/travery/useraction/list/UserActionFeedActivity.kt
@@ -19,6 +19,8 @@ class UserActionFeedActivity : BaseActivity<ActivityUserActionFeedBinding>() {
         setSupportActionBar(toolBar as Toolbar)
         supportActionBar?.title = ""
 
+        // 다른 뷰모델을 재사용하시면 됩니다!
+        // 바인딩어댑터 확인 필요
         viewDataBinding.viewmodel = ViewModelProviders.of(this).get(UserActionListViewModel::class.java)
     }
 }

--- a/app/src/main/java/com/boostcamp/travery/useraction/list/UserActionListAdapter.kt
+++ b/app/src/main/java/com/boostcamp/travery/useraction/list/UserActionListAdapter.kt
@@ -1,0 +1,56 @@
+package com.boostcamp.travery.useraction.list
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ObservableArrayList
+import com.boostcamp.travery.R
+import com.boostcamp.travery.base.BaseViewHolder
+import com.boostcamp.travery.base.ObservableRecyclerViewAdapter
+import com.boostcamp.travery.data.model.UserAction
+import com.boostcamp.travery.databinding.ItemFeedUserActionBinding
+import com.google.android.material.chip.Chip
+import kotlinx.android.synthetic.main.item_feed_user_action.view.*
+
+class UserActionListAdapter(data: ObservableArrayList<UserAction>) : ObservableRecyclerViewAdapter<UserAction, BaseViewHolder>(data) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder {
+        return UserActionFeedViewHolder(DataBindingUtil.inflate(LayoutInflater.from(parent.context),
+                R.layout.item_feed_user_action,
+                parent,
+                false))
+    }
+
+    override fun onBindViewHolder(holder: BaseViewHolder, position: Int) {
+        holder.bind(getItem(position))
+
+        val chipGroup = holder.itemView.chip_group_feed
+
+        if (chipGroup.childCount > 0) {
+            chipGroup.removeAllViews()
+        }
+        getItem(position).hashTag.split(' ').forEach { hashTag ->
+            if (!hashTag.isEmpty()) {
+                Chip(chipGroup.context).apply {
+                    text = hashTag
+                    isClickable = true
+                    isChipIconVisible = false
+                    isCheckedIconVisible = false
+                }.also {
+                    chipGroup.addView(it)
+                }
+            }
+        }
+    }
+}
+
+class UserActionFeedViewHolder(private val binding: ItemFeedUserActionBinding) : BaseViewHolder(binding) {
+    override fun bind(item: Any) {
+        if (item is UserAction) {
+            binding.apply {
+                this.item = item
+                executePendingBindings()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/boostcamp/travery/useraction/list/UserActionListViewModel.kt
+++ b/app/src/main/java/com/boostcamp/travery/useraction/list/UserActionListViewModel.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationManager
 import androidx.core.content.ContextCompat
+import androidx.databinding.ObservableArrayList
 import androidx.lifecycle.MutableLiveData
 import com.boostcamp.travery.MyApplication
 import com.boostcamp.travery.base.BaseViewModel
@@ -19,6 +20,8 @@ import io.reactivex.schedulers.Schedulers
 class UserActionListViewModel(application: Application) : BaseViewModel(application) {
     private var contract: Contract? = null
     private val curLocation = MutableLiveData<Location>()
+
+    val userActionList = ObservableArrayList<UserAction>()
 
     private val userActionRepository =
             UserActionRepository.getInstance(AppDatabase.getInstance(application).daoUserAction())
@@ -44,6 +47,9 @@ class UserActionListViewModel(application: Application) : BaseViewModel(applicat
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe {
                             contract?.onUserActionLoading(it)
+
+                            userActionList.clear()
+                            userActionList.addAll(it)
                         })
     }
 
@@ -61,13 +67,12 @@ class UserActionListViewModel(application: Application) : BaseViewModel(applicat
         val providers = locationManager.getProviders(true)
         var bestLocation: Location? = null
 
-        PackageManager.PERMISSION_GRANTED.let { isGranted ->
-            if (fineLocPerm == isGranted && courseLocPerm == isGranted) {
-                for (provider in providers) {
-                    val mLocation = locationManager.getLastKnownLocation(provider) ?: continue
-                    if (bestLocation == null || mLocation.accuracy < bestLocation!!.accuracy) {
-                        bestLocation = mLocation
-                    }
+        val isGranted = PackageManager.PERMISSION_GRANTED
+        if (fineLocPerm == isGranted && courseLocPerm == isGranted) {
+            for (provider in providers) {
+                val mLocation = locationManager.getLastKnownLocation(provider) ?: continue
+                if (bestLocation == null || mLocation.accuracy < bestLocation.accuracy) {
+                    bestLocation = mLocation
                 }
             }
         }

--- a/app/src/main/java/com/boostcamp/travery/useraction/list/UserActionListViewModel.kt
+++ b/app/src/main/java/com/boostcamp/travery/useraction/list/UserActionListViewModel.kt
@@ -18,26 +18,18 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 
 class UserActionListViewModel(application: Application) : BaseViewModel(application) {
-    private var contract: Contract? = null
     private val curLocation = MutableLiveData<Location>()
+    fun getCurLocation() = curLocation
 
-    val userActionList = ObservableArrayList<UserAction>()
+    val mUserActionList = ObservableArrayList<UserAction>()
+    private val userActionList = MutableLiveData<List<UserAction>>()
+    fun getUserActionList() = userActionList
 
     private val userActionRepository =
             UserActionRepository.getInstance(AppDatabase.getInstance(application).daoUserAction())
 
-    fun getCurLocation() = curLocation
-
     init {
         loadUserActions()
-    }
-
-    interface Contract {
-        fun onUserActionLoading(list: List<UserAction>)
-    }
-
-    fun setContract(contract: Contract) {
-        this.contract = contract
     }
 
     private fun loadUserActions() {
@@ -46,10 +38,10 @@ class UserActionListViewModel(application: Application) : BaseViewModel(applicat
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe {
-                            contract?.onUserActionLoading(it)
+                            userActionList.value = it
 
-                            userActionList.clear()
-                            userActionList.addAll(it)
+                            mUserActionList.clear()
+                            mUserActionList.addAll(it)
                         })
     }
 

--- a/app/src/main/java/com/boostcamp/travery/utils/BindingUtils.kt
+++ b/app/src/main/java/com/boostcamp/travery/utils/BindingUtils.kt
@@ -14,18 +14,18 @@ import com.boostcamp.travery.GlideApp
 import com.boostcamp.travery.R
 import com.boostcamp.travery.main.MainViewModel
 import com.boostcamp.travery.main.adapter.CourseListAdapter
-import com.boostcamp.travery.useraction.save.UserActionImageListAdapter
-import com.boostcamp.travery.useraction.save.UserActionSaveViewModel
 import com.boostcamp.travery.search.SearchResultViewModel
 import com.boostcamp.travery.search.UserActionSearchAdapter
 import com.boostcamp.travery.useraction.detail.UserActionDetailViewModel
 import com.boostcamp.travery.useraction.detail.UserActionImageAdapter
-import com.bumptech.glide.Glide
+import com.boostcamp.travery.useraction.list.UserActionListAdapter
+import com.boostcamp.travery.useraction.list.UserActionListViewModel
+import com.boostcamp.travery.useraction.save.UserActionImageListAdapter
+import com.boostcamp.travery.useraction.save.UserActionSaveViewModel
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.MultiTransformation
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
-import com.bumptech.glide.load.resource.bitmap.CircleCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
@@ -239,7 +239,6 @@ object BindingUtils {
         }
     }
 
-
     /**
      * 선택한 방향으로 isAnimated 값에 따라 translation 애니메이션이 시작됨.
      * 애니메이션이 끝나고 끝난자리에 고정됨.
@@ -275,5 +274,16 @@ object BindingUtils {
             }
         }
 
+    }
+
+    @JvmStatic
+    @BindingAdapter("listAdapter")
+    fun setAdapter(recyclerView: RecyclerView, viewModel: UserActionListViewModel) {
+        val adapter = UserActionListAdapter(viewModel.userActionList)
+
+        recyclerView.apply {
+            layoutManager = LinearLayoutManager(recyclerView.context)
+            this.adapter = adapter
+        }
     }
 }

--- a/app/src/main/java/com/boostcamp/travery/utils/BindingUtils.kt
+++ b/app/src/main/java/com/boostcamp/travery/utils/BindingUtils.kt
@@ -279,7 +279,7 @@ object BindingUtils {
     @JvmStatic
     @BindingAdapter("listAdapter")
     fun setAdapter(recyclerView: RecyclerView, viewModel: UserActionListViewModel) {
-        val adapter = UserActionListAdapter(viewModel.userActionList)
+        val adapter = UserActionListAdapter(viewModel.mUserActionList)
 
         recyclerView.apply {
             layoutManager = LinearLayoutManager(recyclerView.context)

--- a/app/src/main/res/layout/activity_user_action_feed.xml
+++ b/app/src/main/res/layout/activity_user_action_feed.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="viewmodel"
+            type="com.boostcamp.travery.useraction.list.UserActionListViewModel" />
+    </data>
+
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/colorPrimary"
+        android:orientation="vertical">
+
+        <include
+            android:id="@+id/toolBar"
+            layout="@layout/toolbar" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_user_action_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="@dimen/activity_content_padding"
+            app:listAdapter="@{viewmodel}" />
+
+    </androidx.appcompat.widget.LinearLayoutCompat>
+</layout>

--- a/app/src/main/res/layout/item_feed_user_action.xml
+++ b/app/src/main/res/layout/item_feed_user_action.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="item"
+            type="com.boostcamp.travery.data.model.UserAction" />
+    </data>
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="5dp"
+        android:padding="@dimen/activity_content_padding"
+        android:background="?android:attr/selectableItemBackground">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:padding="@dimen/activity_content_padding">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/iv_loc"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:src="@drawable/ic_location_on_black_24dp"
+                app:layout_constraintBottom_toBottomOf="@+id/tv_user_action_detail_title"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/tv_user_action_detail_title"
+                app:tint="@color/colorAccent" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_user_action_detail_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:text="@{item.title}"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                app:layout_constraintStart_toEndOf="@+id/iv_loc"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/colorAccent"
+                tools:text="강남역에서의 점심" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_user_action_detail_location"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/string_temp_useraction_detail_location"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_user_action_detail_title" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_user_action_detail_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:date="@{item.date}"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_user_action_detail_location"
+                tools:text="2019.02.04 AM 02:39" />
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/rv_image_list"
+                android:layout_width="match_parent"
+                android:layout_height="300dp"
+                android:layout_marginTop="5dp"
+                android:scaleType="centerCrop"
+                app:image="@{item.mainImage}"
+                app:layout_constraintTop_toBottomOf="@id/tv_user_action_detail_date" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_content"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:padding="5dp"
+                android:text="@{item.body}"
+                android:textSize="17sp"
+                android:layout_marginEnd="10dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/rv_image_list"
+                app:layout_constraintEnd_toEndOf="parent"
+                tools:text="텍스트뷰 입니다. 입니다. 입니다." />
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/chip_group_feed"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:layout_marginBottom="10dp"
+                app:chipSpacing="@dimen/chip_group_child_spacing"
+                app:chipSpacingVertical="@dimen/chip_group_child_spacing_vertical"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_content" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</layout>


### PR DESCRIPTION
## 개요
- 활동 피드화면입니다.
  - 현재 지도 위에 클러스터링 마커를 보여줄 때 사용했던 UserActionListViewModel 을 재사용하고있습니다.
  - 리사이클러뷰로 구성되어있고, 현재 피드의 이미지는 메인 이미지만 보여주도록 구현되었습니다.

  - 터치 이벤트는 없습니다.
![default](https://user-images.githubusercontent.com/26956811/52799237-c8a8c780-30bc-11e9-893b-5d2d5f2c33b8.jpg)


## 이슈
resolved #128
